### PR TITLE
Feat/list suggested products

### DIFF
--- a/src/app/product-details/[id]/page.tsx
+++ b/src/app/product-details/[id]/page.tsx
@@ -39,6 +39,15 @@ export default async function ProductDetails({ params }: ProductDetailsProps) {
   const suggestedProducts = await db.product.findMany({
     where: {
       categoryId: product.categoryId,
+      AND: {
+        NOT: [
+          {
+            id: {
+              equals: product.id,
+            },
+          },
+        ],
+      },
     },
     include: {
       category: true,

--- a/src/app/product-details/[id]/page.tsx
+++ b/src/app/product-details/[id]/page.tsx
@@ -4,6 +4,7 @@ import { Plus, Minus, ArrowLeft } from "lucide-react";
 import { db } from "@/lib/db";
 import { formatCurrency } from "@/lib/formatCurrency";
 import { Button } from "@/components/ui/button";
+import { ProductList } from "@/components/product/product-list";
 
 interface ProductDetailsProps {
   params: Promise<{
@@ -35,9 +36,18 @@ export default async function ProductDetails({ params }: ProductDetailsProps) {
     );
   }
 
+  const suggestedProducts = await db.product.findMany({
+    where: {
+      categoryId: product.categoryId,
+    },
+    include: {
+      category: true,
+    },
+  });
+
   return (
     <div className="w-full flex justify-center">
-      <div className="w-full flex flex-col items-center gap-6 px-6 md:max-w-7xl">
+      <div className="w-full flex flex-col items-center gap-6 px-6 md:max-w-9/12">
         <Link
           href="/"
           className="w-full flex items-center justify-self-start gap-2"
@@ -45,13 +55,13 @@ export default async function ProductDetails({ params }: ProductDetailsProps) {
           <ArrowLeft />
           <span>Voltar</span>
         </Link>
-        <div className="h-96 w-full md:flex md:gap-6 md:max-w-5xl">
-          <div className="relative w-full h-full">
+        <div className="h-full w-full lg:flex md:gap-6 md:max-w-5xl rounded-2xl">
+          <div className="relative min-h-96 w-full rounded-2xl">
             <Image
               alt="Product image"
               src={product.imageUrl}
               fill
-              className="rounded-lg object-cover md:object-center"
+              className="object-contain rounded-lg"
             />
           </div>
           <div className="flex flex-col gap-3 mt-4">
@@ -63,20 +73,24 @@ export default async function ProductDetails({ params }: ProductDetailsProps) {
               {formatCurrency(product.price)}
             </span>
             <div className="w-full flex items-center gap-2 mt-4">
-              <div className="flex justify-center items-center flex-1 border rounded-lg">
-                <button className="px-6 py-2">
+              <div className="w-full flex justify-center items-center border rounded-lg">
+                <button className="flex justify-center flex-1 py-2 hover:cursor-pointer md:px-6">
                   <Minus />
                 </button>
                 <span className="font-semibold">{1}</span>
-                <button className="px-6 py-2">
+                <button className="flex justify-center flex-1 py-2 hover:cursor-pointer md:px-6">
                   <Plus />
                 </button>
               </div>
-              <Button size={"lg"} className="flex-2">
-                Adicionar ao carrinho
-              </Button>
+              <Button size={"lg"}>Adicionar ao carrinho</Button>
             </div>
           </div>
+        </div>
+        <div className="w-full my-4">
+          <span className="flex py-6 font-medium">
+            Outros produtos da categoria {product.category.name}
+          </span>
+          <ProductList products={suggestedProducts} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
On this pull request, it's being added a feature to display the products with the same category as the product selected by the user.

The list with these products it's being displayed right below the selected product image and information, on product details page:

![image](https://github.com/user-attachments/assets/44940831-69d9-4a45-baa8-5df7cf57d9fc)

Was implemented on this feature:

- [x] - The listing of products with the same category as the selected product;
- [x] - A validation to not show the already selected product among the suggested ones;
- [x] - A responsive design to break the line if there is no enough space to display all the products in the same line.